### PR TITLE
add lepton triggers

### DIFF
--- a/ggNtuplizer/interface/ggNtuplizer.h
+++ b/ggNtuplizer/interface/ggNtuplizer.h
@@ -51,6 +51,7 @@ class ggNtuplizer : public edm::EDAnalyzer {
   Int_t matchDoublePhotonTriggerFilters(double pt, double eta, double phi);
   Int_t matchMuonTriggerFilters(double pt, double eta, double phi);
   Int_t matchJetTriggerFilters(double pt, double eta, double phi);
+  Int_t matchL1TriggerFilters(double pt, double eta, double phi);
   Double_t deltaPhi(Double_t phi1, Double_t phi2);
   Double_t deltaR(Double_t eta1, Double_t phi1, Double_t eta2, Double_t phi2);
   Double_t getMiniIsolation(edm::Handle<pat::PackedCandidateCollection> pfcands, const reco::Candidate* ptcl,  

--- a/ggNtuplizer/plugins/ggNtuplizer_electrons.cc
+++ b/ggNtuplizer/plugins/ggNtuplizer_electrons.cc
@@ -79,6 +79,7 @@ vector<float>  eleKFHits_;
 vector<float>  eleKFChi2_;
 vector<float>  eleGSFChi2_;
 vector<int>    eleFiredTrgs_;
+vector<int>    eleFiredL1Trgs_;
 
 vector<UShort_t> eleIDbit_;
 
@@ -200,6 +201,7 @@ void ggNtuplizer::branchesElectrons(TTree* tree) {
   tree->Branch("eleBCSieip",                  &eleBCSieip_);
   tree->Branch("eleBCSipip",                  &eleBCSipip_);
   tree->Branch("eleFiredTrgs",                &eleFiredTrgs_);
+  tree->Branch("eleFiredL1Trgs",              &eleFiredL1Trgs_);
 
   if (runeleIDVID_) tree->Branch("eleIDbit",  &eleIDbit_);
 
@@ -318,6 +320,7 @@ void ggNtuplizer::fillElectrons(const edm::Event &e, const edm::EventSetup &es, 
   eleBCSieip_                 .clear();
   eleBCSipip_                 .clear();
   eleFiredTrgs_               .clear();
+  eleFiredL1Trgs_             .clear();
   eleIDbit_                   .clear();
 
   nEle_ = 0;
@@ -404,6 +407,7 @@ void ggNtuplizer::fillElectrons(const edm::Event &e, const edm::EventSetup &es, 
     eleHoverE_          .push_back(iEle->hcalOverEcal());
 
     eleFiredTrgs_       .push_back(matchElectronTriggerFilters(iEle->pt(), iEle->eta(), iEle->phi()));
+    eleFiredL1Trgs_     .push_back(matchL1TriggerFilters(iEle->pt(), iEle->eta(), iEle->phi()));
 
     ///https://cmssdt.cern.ch/SDT/doxygen/CMSSW_7_2_2/doc/html/d8/dac/GsfElectron_8h_source.html
     eleEoverP_          .push_back(iEle->eSuperClusterOverP());

--- a/ggNtuplizer/plugins/ggNtuplizer_muons.cc
+++ b/ggNtuplizer/plugins/ggNtuplizer_muons.cc
@@ -36,6 +36,7 @@ vector<float>  muPFNeuIso_;
 vector<float>  muPFPUIso_;
 vector<float>  muPFMiniIso_;
 vector<int>    muFiredTrgs_;
+vector<int>    muFiredL1Trgs_;
 vector<float>  muInnervalidFraction_;
 vector<float>  musegmentCompatibility_;
 vector<float>  muchi2LocalPosition_;
@@ -76,6 +77,7 @@ void ggNtuplizer::branchesMuons(TTree* tree) {
   tree->Branch("muPFPUIso",     &muPFPUIso_);
   tree->Branch("muPFMiniIso",   &muPFMiniIso_);
   tree->Branch("muFiredTrgs",   &muFiredTrgs_);
+  tree->Branch("muFiredL1Trgs", &muFiredL1Trgs_);
   tree->Branch("muInnervalidFraction",   &muInnervalidFraction_);
   tree->Branch("musegmentCompatibility", &musegmentCompatibility_);
   tree->Branch("muchi2LocalPosition",    &muchi2LocalPosition_);
@@ -117,6 +119,7 @@ void ggNtuplizer::fillMuons(const edm::Event& e, math::XYZPoint& pv, reco::Verte
   muPFPUIso_    .clear();
   muPFMiniIso_  .clear();
   muFiredTrgs_  .clear();
+  muFiredL1Trgs_.clear();
   muInnervalidFraction_  .clear();
   musegmentCompatibility_.clear();
   muchi2LocalPosition_   .clear();
@@ -158,6 +161,7 @@ void ggNtuplizer::fillMuons(const edm::Event& e, math::XYZPoint& pv, reco::Verte
     muIsHighPtID_.push_back(iMu->isHighPtMuon(vtx));
 
     muFiredTrgs_.push_back(matchMuonTriggerFilters(iMu->pt(), iMu->eta(), iMu->phi()));
+    muFiredL1Trgs_.push_back(matchL1TriggerFilters(iMu->pt(), iMu->eta(), iMu->phi()));
 
     muBestTrkPtError_        .push_back(iMu->muonBestTrack()->ptError());
     muBestTrkPt_             .push_back(iMu->muonBestTrack()->pt());

--- a/ggNtuplizer/plugins/ggNtuplizer_photons.cc
+++ b/ggNtuplizer/plugins/ggNtuplizer_photons.cc
@@ -84,6 +84,7 @@ vector<float>  phoSeedBCEta_;
 vector<float>  phoIDMVA_;
 vector<Int_t>  phoFiredSingleTrgs_;
 vector<Int_t>  phoFiredDoubleTrgs_;
+vector<Int_t>  phoFiredL1Trgs_;
 vector<float>  phoEcalRecHitSumEtConeDR03_;
 vector<float>  phohcalDepth1TowerSumEtConeDR03_;
 vector<float>  phohcalDepth2TowerSumEtConeDR03_;
@@ -200,6 +201,7 @@ void ggNtuplizer::branchesPhotons(TTree* tree) {
   tree->Branch("phoIDMVA",                        &phoIDMVA_);
   tree->Branch("phoFiredSingleTrgs",              &phoFiredSingleTrgs_);
   tree->Branch("phoFiredDoubleTrgs",              &phoFiredDoubleTrgs_);
+  tree->Branch("phoFiredL1Trgs",                  &phoFiredL1Trgs_);
   //tree->Branch("phoSeedTime",                     &phoSeedTime_);
   //tree->Branch("phoSeedTimeFull5x5",              &phoSeedTimeFull5x5_);
   //tree->Branch("phoMIPChi2",                      &phoMIPChi2_);
@@ -295,6 +297,7 @@ void ggNtuplizer::fillPhotons(const edm::Event& e, const edm::EventSetup& es) {
   phoIDMVA_             .clear();
   phoFiredSingleTrgs_   .clear();
   phoFiredDoubleTrgs_   .clear();
+  phoFiredL1Trgs_       .clear();
   phoxtalBits_          .clear();
   /*
   phoSeedTime_          .clear();
@@ -519,6 +522,7 @@ void ggNtuplizer::fillPhotons(const edm::Event& e, const edm::EventSetup& es) {
 
     phoFiredSingleTrgs_     .push_back(matchSinglePhotonTriggerFilters(iPho->et(), iPho->eta(), iPho->phi()));
     phoFiredDoubleTrgs_     .push_back(matchDoublePhotonTriggerFilters(iPho->et(), iPho->eta(), iPho->phi()));
+    phoFiredL1Trgs_         .push_back(matchL1TriggerFilters(iPho->et(), iPho->eta(), iPho->phi()));
 
     std::vector<float> vCov = lazyToolnoZS.localCovariances( *((*iPho).superCluster()->seed()) );
     //const float see = (isnan(vCov[0]) ? 0. : sqrt(vCov[0]));

--- a/ggNtuplizer/plugins/ggNtuplizer_trigger.cc
+++ b/ggNtuplizer/plugins/ggNtuplizer_trigger.cc
@@ -11,6 +11,7 @@ vector<float> trgSinglePhoPt[32], trgSinglePhoEta[32], trgSinglePhoPhi[32];
 vector<float> trgDoublePhoPt[32], trgDoublePhoEta[32], trgDoublePhoPhi[32];
 vector<float> trgMuPt[32],  trgMuEta[32],  trgMuPhi[32];
 vector<float> trgJetPt[32], trgJetEta[32], trgJetPhi[32];
+vector<float> trgL1Eta[32],  trgL1Phi[32];
 
 void ggNtuplizer::initTriggerFilters(const edm::Event &e) {
   // Fills the arrays above.
@@ -32,6 +33,8 @@ void ggNtuplizer::initTriggerFilters(const edm::Event &e) {
     trgJetPt [i].clear();
     trgJetEta[i].clear();
     trgJetPhi[i].clear();
+    trgL1Eta[i].clear();
+    trgL1Phi[i].clear();
   }
 
   // filter => index (in trg*[] arrays) mappings
@@ -40,16 +43,86 @@ void ggNtuplizer::initTriggerFilters(const edm::Event &e) {
   static std::map<string,size_t> phoDoubleFilters;
   static std::map<string,size_t> muFilters;
   static std::map<string,size_t> jetFilters;
+  static std::map<string,size_t> l1Filters;
 
   // one-time initialization
   if (eleFilters.size() == 0) {
-    eleFilters["hltEle27WPLooseGsfTrackIsoFilter"] = 0;
-    eleFilters["hltEle25WP60SC4HcalIsoFilter"]     = 1;
+    eleFilters["hltEle27WPLooseGsfTrackIsoFilter"] 							  = 0;
+    eleFilters["hltEle25WP60SC4HcalIsoFilter"]      							  = 1;
     // for HLT_Ele23_WPLoose_Gsf_v and EventTree
     eleFilters["hltEGL1SingleEG40ORSingleIsoEG22erOrSingleIsoEG24erORSingleIsoEG24OrSingleIsoEG26Filter"] = 2;
+    //HLT_Ele22_eta2p1_WPLoose_Gsf_v3
+    eleFilters["hltSingleEle22WPLooseGsfTrackIsoFilter"] 						  = 3;
+    //HLT_Ele24_eta2p1_WPLoose_Gsf_v1
+    eleFilters["hltSingleEle24WPLooseGsfTrackIsoFilter"] 						  = 4;
+    //HLT_Ele25_WPTight_Gsf_v1
+    eleFilters["hltEle25WPTightGsfTrackIsoFilter"] 							  = 5;
+    //HLT_Ele25_eta2p1_WPLoose_Gsf_v1
+    eleFilters["hltEle25erWPLooseGsfTrackIsoFilter"]							  = 6;
+    //HLT_Ele25_eta2p1_WPTight_Gsf_v1
+    eleFilters["hltEle25erWPTightGsfTrackIsoFilter"]							  = 7;
+    //HLT_Ele27_WPLoose_Gsf_v1
+    eleFilters["hltEle27noerWPLooseGsfTrackIsoFilter"] 							  = 8;
+    //HLT_Ele27_WPLoose_Gsf_v
+    eleFilters["hltEG27L1IsoEG22erORIsoEG24erORIsoEG24ORIsoEG26OREG40EtFilter"]	                          = 9; 	
+    //HLT_Ele27_eta2p1_WPLoose_Gsf_v2, HLT_Ele27_eta2p1_WPLoose_Gsf_LooseIsoPFTau*                             
+    eleFilters["hltEle27erWPLooseGsfTrackIsoFilter"]                                                      = 10;
+    //HLT_Ele27_eta2p1_WPTight_Gsf                                                                             
+    eleFilters["hltEle27erWPTightGsfTrackIsoFilter"]                                                      = 11;
+    //HLT_Ele27_WPTight_Gsf                                                                                    
+    eleFilters["hltEle27WPTightGsfTrackIsoFilter"]                                                        = 12;
+    //HLT_Ele32_eta2p1_WPTight_Gsf                                                                             
+    eleFilters["hltEle32WPTightGsfTrackIsoFilter"]                                                        = 13;
+    //HLT_Ele35_WPLoose_Gsf                                                                                    
+    eleFilters["hltEle35WPLooseGsfTrackIsoFilter"]                                                        = 14;
+    //HLT_Ele45_WPLoose_Gsf                                                                                    
+    eleFilters["hltEle45WPLooseGsfTrackIsoFilter"]                                                        = 15;
+    //HLT_Ele22_eta2p1_WPLoose_Gsf_LooseIsoPFTau20_SingleL1 
+    eleFilters["hltEle22WPLooseL1SingleIsoEG20erGsfTrackIsoFilter"]                                       = 16;
+    //HLT_Ele22_eta2p1_WPLoose_Gsf_LooseIsoPFTau20_SingleL1                                                    
+    eleFilters["hltOverlapFilterSingleIsoEle22WPLooseGsfLooseIsoPFTau20"]                                 = 17; 
+    //HLT_Ele24_eta2p1_WPLoose_Gsf_LooseIsoPFTau20_SingleL1                                                    
+    eleFilters["hltEle24WPLooseL1SingleIsoEG22erGsfTrackIsoFilter"]                                       = 18;
+    //HLT_Ele24_eta2p1_WPLoose_Gsf_LooseIsoPFTau20                                                             
+    eleFilters["hltEle24WPLooseL1IsoEG22erTau20erGsfTrackIsoFilter"]                                      = 19;
+    //HLT_Ele24_eta2p1_WPLoose_Gsf_LooseIsoPFTau20_v1                                                          
+    eleFilters["hltOverlapFilterIsoEle24WPLooseGsfLooseIsoPFTau20"]                                       = 20;
+    //HLT_Diphoton30_18_R9Id_OR_IsoCaloId_AND_HE_R9Id_Mass90                                                   
+    eleFilters["hltEG18Iso60CaloId15b35eHE12R9Id50b80eTrackIsoUnseededLastFilter"]                        = 21;
+    eleFilters["hltEG18R9Id85b90eHE12R9Id50b80eR9UnseededLastFilter"]                                     = 22;       
+    //HLT_DiMu9_Ele9_CaloIdL_TrackIdL                                                                     
+    eleFilters["hltDiMu9Ele9CaloIdLTrackIdLElectronlegDphiFilter"]                                        = 23; 
+    //HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL                                                    
+    eleFilters["hltMu23TrkIsoVVLEle12CaloIdLTrackIdLIsoVLElectronlegTrackIsoFilter"]	                  = 24;
+    //HLT_Mu8_DiEle12_CaloIdL_TrackIdL 
+    eleFilters["hltMu8DiEle12CaloIdLTrackIdLElectronlegDphiFilter"]                                       = 25;
+    //HLT_Mu8_TrkIsoVVL_Ele17_CaloIdL_TrackIdL_IsoVL 
+    eleFilters["hltMu8TrkIsoVVLEle17CaloIdLTrackIdLIsoVLElectronlegTrackIsoFilter"]                       = 26;
+    //HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL 
+    eleFilters["hltMu8TrkIsoVVLEle23CaloIdLTrackIdLIsoVLElectronlegTrackIsoFilter"]                       = 27;
 
-    // for HLT_Iso(Tk)Mu20_v
-    muFilters["hltL1sSingleMu18"] = 0;
+
+    muFilters["hltL3crIsoL1sMu20L1f0L2f10QL3f22QL3trkIsoFiltered0p09"] 		 = 0; //HLT_IsoMu22_v2
+    muFilters["hltL3crIsoL1sMu22L1f0L2f10QL3f24QL3trkIsoFiltered0p09"] 		 = 1; //HLT_IsoMu24_v1
+    muFilters["hltL3fL1sL1Mu5IsoEG18L1f5L2f7L3Filtered17"] 			 = 2; //HLT_Mu17_Photon*  muon
+    muFilters["hltDiMu9Ele9CaloIdLTrackIdLMuonlegL3Filtered9"] 			 = 3; //HLT_DiMu9_Ele9_CaloIdL_TrackIdL_v3 muon
+    muFilters["hltMu23TrkIsoVVLEle12CaloIdLTrackIdLIsoVLMuonlegL3IsoFiltered23"] = 4; //HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL
+    muFilters["hltMu8DiEle12CaloIdLTrackIdLMuonlegL3Filtered8"] 		 = 5; //LT_Mu8_DiEle12_CaloIdL_TrackIdL_v3 muon
+    muFilters["hltMu8TrkIsoVVLEle17CaloIdLTrackIdLIsoVLMuonlegL3IsoFiltered8"]   = 6; //HLT_Mu8_TrkIsoVVL_Ele17_CaloIdL_TrackIdL_IsoVL
+    muFilters["hltMu8TrkIsoVVLEle23CaloIdLTrackIdLIsoVLMuonlegL3IsoFiltered8"]   = 7; //HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL
+    muFilters["hltDiMuonGlb17Trk8DzFiltered0p2"] 				 = 8; //HLT_Mu17_TkMu8_DZ
+    muFilters["hltDiMuonGlb17Glb8RelTrkIsoFiltered0p4"] 			 = 9; //HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL
+    muFilters["hltDiMuonGlb17Glb8RelTrkIsoFiltered0p4DzFiltered0p2"] 		 = 10; //HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ
+    muFilters["hltDiMuonGlb17Trk8RelTrkIsoFiltered0p4"] 			 = 11; //HLT_Mu17_TrkIsoVVL_TkMu8_TrkIsoVVL
+    muFilters["hltDiMuonGlb17Trk8RelTrkIsoFiltered0p4DzFiltered0p2"] 		 = 12; //HLT_Mu17_TrkIsoVVL_TkMu8_TrkIsoVVL_DZ
+    muFilters["hltL3fL1sMu1lqL1f0L2f10L3Filtered17TkIsoFiltered0p4"] 		 = 13; //HLT_Mu17_TrkIsoVVL
+    muFilters["hltDiMuonGlb27Trk8DzFiltered0p2"] 				 = 14; //HLT_Mu27_TkMu8
+    muFilters["hltDiMuonGlb30Trk11DzFiltered0p2"] 				 = 15; //HLT_Mu30_TkMu11
+    muFilters["hltL3crIsoL1sDoubleMu125L1f16erL2f10QL3f17QL3Dz0p2L3crIsoRhoFiltered0p15IterTrk02"] = 16; //HLT_DoubleIsoMu17_eta2p1
+    muFilters["hltL3crIsoL1sMu22Or25L1f0L2f10QL3f27QL3trkIsoFiltered0p09"] 	 = 17; //HLT_IsoMu27
+    muFilters["hltL3fL1sMu20L1f0Tkf22QL3trkIsoFiltered0p09"] 	  		 = 18; //HLT_IsoTkMu22
+    muFilters["hltL3fL1sMu22L1f0Tkf24QL3trkIsoFiltered0p09"] 			 = 19; //HLT_IsoTkMu24
+    muFilters["hltL3fL1sMu22Or25L1f0Tkf27QL3trkIsoFiltered0p09"] 		 = 20; //HLT_IsoTkMu27
 
     phoSingleFilters["hltEG22HEFilter"]    = 0;
     phoSingleFilters["hltEG30HEFilter"]    = 1;
@@ -64,6 +137,7 @@ void ggNtuplizer::initTriggerFilters(const edm::Event &e) {
     phoSingleFilters["hltEG300erEtFilter"] = 10;
     phoSingleFilters["hltEG500HEFilter"]   = 11;
     phoSingleFilters["hltEG600HEFilter"]   = 12;
+    phoSingleFilters["hltEG90CaloIdLHEFilter"]   = 13;
 
     //L1 seed for diphoton triggers  
     phoDoubleFilters["hltSingleEGL1SingleEG40ORL1SingleEG25ORL1DoubleEG2210ORL1DoubleEG1510Filter"]    = 0;
@@ -103,6 +177,8 @@ void ggNtuplizer::initTriggerFilters(const edm::Event &e) {
     phoDoubleFilters["hltEG22Iso50T80LCaloId24b40eHE10R9Id65TrackIsoUnseededLastFilter"]                    = 25;
     phoDoubleFilters["hltEG36R9Id85HE10R9Id65R9IdEta2LastFilter"]                                           = 26;
     phoDoubleFilters["hltEG36Iso50T80LCaloId24b40eHE10R9Id65Eta2HcalIsoLastFilter"]                         = 27;
+    phoDoubleFilters["hltMu17Photon22CaloIdLL1ISOHEFilter"]                                                 = 28;
+    phoDoubleFilters["hltMu17Photon30CaloIdLL1ISOHEFilter"]                                                 = 29;
 
     jetFilters["hltSinglePFJet40"]  =  0;
     jetFilters["hltSinglePFJet60"]  =  1;
@@ -114,6 +190,32 @@ void ggNtuplizer::initTriggerFilters(const edm::Event &e) {
     jetFilters["hltSinglePFJet400"] =  7;
     jetFilters["hltSinglePFJet450"] =  8;
     jetFilters["hltSinglePFJet500"] =  9;
+
+    l1Filters["hltL1sSingleEG26"]    			 		= 0 ;
+    l1Filters["hltL1sSingleEG40"]					= 1;
+    l1Filters["hltL1sSingleEG40IorSingleIsoEG22erIorSingleIsoEG24er"]	= 2;
+    l1Filters["hltL1sSingleIsoEG20erIorSingleIsoEG22erIorSingleEG40"]	= 3;
+    l1Filters["hltL1sSingleIsoEG22erIorSingleIsoEG24erIorSingleEG40"]	= 4;
+    l1Filters["hltL1sSingleEG40IorSingleIsoEG22erIorSingleIsoEG24erIorSingleIsoEG24IorSingleIsoEG26"] = 5;
+    l1Filters["hltL1sHTT200IorHTT220IorHTT240lorHTT255IorHTT270lorHTT280lorHTT300lorHTT320"]	      = 6;
+    l1Filters["hltL1sEG27erHTT200IorHTT280IorHTT300"]			= 7;
+    l1Filters["hltL1sIsoEG22erTau20erdEtaMin0p2"]			= 8;
+    l1Filters["hltL1sSingleMu18"]					= 9;
+    l1Filters["hltL1sSingleMu22"]					= 10;
+    l1Filters["hltL1sSingleMu22Or25"]					= 11;
+    l1Filters["hltL1sMu5IsoEG18"]					= 12; //HLT_Mu17_Photon*
+    l1Filters["hltL1sMu20EG10"]                   			= 13; //HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL,
+    l1Filters["hltL1sDoubleMu7EG7"]              			= 14; //HLT_DiMu9_Ele9_CaloIdL_TrackIdL_v3
+    l1Filters["hltL1sMu6DoubleEG10"]           				= 15; //LT_Mu8_DiEle12_CaloIdL_TrackIdL_v3
+    l1Filters["hltL1sMu5EG15"]                   			= 16; //HLT_Mu8_TrkIsoVVL_Ele17_CaloIdL_TrackIdL_IsoVL_v3
+    l1Filters["hltL1sMu5EG20IorMu5IsoEG18"]      			= 17; //HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_v3
+    l1Filters["hltL1sDoubleMu114IorDoubleMu125"]			= 18; //DiMuon
+    l1Filters["hltL1sSingleMu10LowQ"]         				= 19; //HLT_Mu17_TrkIsoVVL_v2
+    l1Filters["hltL1sL1SingleEG40ORL1SingleEG35ORL1DoubleEG2210ORL1DoubleEG1510"]                     = 20; 
+    l1Filters["hltL1sDiPhotonSeeds"]       				= 21;
+    l1Filters["hltL1sSingleAndDoubleEGor"]                              = 22;
+    l1Filters["hltL1sSingleEG40IorSingleIsoEG26IorSingleIsoEG24IorDoubleEG1510IorDoubleEG2212IorDoubleEG1817"] = 23;
+    
   }
   
   // AOD vs miniAOD
@@ -134,6 +236,7 @@ void ggNtuplizer::initTriggerFilters(const edm::Event &e) {
       std::map<string,size_t>::iterator idxPhoDouble = phoDoubleFilters.find(label);
       std::map<string,size_t>::iterator idxMu  = muFilters.find(label);
       std::map<string,size_t>::iterator idxJet = jetFilters.find(label);
+      std::map<string,size_t>::iterator idxL1  = l1Filters.find(label);
 
       // electron filters
       if (idxEle != eleFilters.end()) {
@@ -195,6 +298,17 @@ void ggNtuplizer::initTriggerFilters(const edm::Event &e) {
           trgJetPhi[idx].push_back(trgV.phi());
         }
       }
+
+      // L1 filters
+      if (idxL1 != l1Filters.end()) {
+        size_t idx = idxL1->second;
+
+        for (size_t iK = 0; iK < keys.size(); ++iK) {
+          const trigger::TriggerObject& trgV = trgObjects.at(keys[iK]);
+          trgL1Eta[idx].push_back(trgV.eta());
+          trgL1Phi[idx].push_back(trgV.phi());
+        }
+      }
     } // HLT filter loop
 
     return;
@@ -224,6 +338,7 @@ void ggNtuplizer::initTriggerFilters(const edm::Event &e) {
       std::map<string,size_t>::iterator idxPhoDouble = phoDoubleFilters.find(label);
       std::map<string,size_t>::iterator idxMu  = muFilters.find(label);
       std::map<string,size_t>::iterator idxJet = jetFilters.find(label);
+      std::map<string,size_t>::iterator idxL1 = l1Filters.find(label);
 
       // electron filters
       if (idxEle != eleFilters.end()) {
@@ -263,6 +378,13 @@ void ggNtuplizer::initTriggerFilters(const edm::Event &e) {
         trgJetPt [idx].push_back(obj.pt());
         trgJetEta[idx].push_back(obj.eta());
         trgJetPhi[idx].push_back(obj.phi());
+      }
+
+      // L1 filters
+      if (idxL1 != l1Filters.end()) {
+        size_t idx = idxL1->second;
+        trgL1Eta[idx].push_back(obj.eta());
+        trgL1Phi[idx].push_back(obj.phi());
       }
     }
   }
@@ -342,6 +464,21 @@ Int_t ggNtuplizer::matchJetTriggerFilters(double pt, double eta, double phi) {
     for (size_t v = 0; v < trgJetPt[f].size(); ++v)
       if (fabs(pt - trgJetPt[f][v])/trgJetPt[f][v] < trgFilterDeltaPtCut_ &&
           deltaR(eta, phi, trgJetEta[f][v], trgJetPhi[f][v]) < trgFilterDeltaRCut_) {
+        result |= (1<<f);
+        break;
+      }
+
+  return result;
+}
+
+Int_t ggNtuplizer::matchL1TriggerFilters(double pt, double eta, double phi) {
+
+  // bits in the return value correspond to decisions from filters defined above
+  Int_t result = 0;
+
+  for (size_t f = 0; f < 32; ++f)
+    for (size_t v = 0; v < trgL1Eta[f].size(); ++v)
+      if (deltaR(eta, phi, trgL1Eta[f][v], trgL1Phi[f][v]) < trgFilterDeltaRCut_) {
         result |= (1<<f);
         break;
       }


### PR DESCRIPTION
A list of lepton trigger objects have been added to the ggNtuplizer_trigger.cc code.
Created three new variables named XFiredL1Trgs_, where X = muon, ele, pho. No pt comparison is required for L1 trigger matching. 
